### PR TITLE
Handle cert issuer create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .envrc
+**.aliases

--- a/controller/Cargo.lock
+++ b/controller/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1686,6 +1687,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -30,3 +30,4 @@ thiserror = "1.0"
 
 # utils
 chrono = "0.4"
+uuid = { version = "0.8", features = ["v4"] }

--- a/controller/kubernetes/ok.yaml
+++ b/controller/kubernetes/ok.yaml
@@ -7,6 +7,8 @@ spec:
   namespaces:
     - default
     - praveen
+    - avencera
+    - doesnt-exist
   dnsProvider:
     provider: cloudflare
     key: thisIsMyKey

--- a/controller/src/cert_issuer.rs
+++ b/controller/src/cert_issuer.rs
@@ -9,11 +9,11 @@ use serde::{Deserialize, Serialize};
 #[kube(group = "certmaster.kuberails.com", version = "v1")]
 #[serde(rename_all = "camelCase")]
 pub struct CertIssuerSpec {
-    domain_name: String,
-    dns_provider: DnsProviderSpec,
-    secret_name: Option<String>,
+    pub domain_name: String,
+    pub dns_provider: DnsProviderSpec,
+    pub secret_name: Option<String>,
     #[serde(default = "default_namespace")]
-    namespaces: Vec<String>,
+    pub namespaces: Vec<String>,
 }
 
 fn default_namespace() -> Vec<String> {
@@ -22,13 +22,13 @@ fn default_namespace() -> Vec<String> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-struct DnsProviderSpec {
-    provider: DnsProvider,
-    key: String,
-    secret_key: String,
+pub struct DnsProviderSpec {
+    pub provider: DnsProvider,
+    pub key: String,
+    pub secret_key: String,
 }
 #[derive(Serialize, Deserialize, Clone, Debug)]
-enum DnsProvider {
+pub enum DnsProvider {
     #[serde(rename = "digtalocean")]
     DigitalOcean,
     #[serde(rename = "cloudflare")]

--- a/controller/src/certificate.rs
+++ b/controller/src/certificate.rs
@@ -1,23 +1,57 @@
 use crate::cert_issuer::{self, CertIssuer};
 use crate::error::Error;
 use crate::store::Store;
+use futures::future::{self};
 use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
 use k8s_openapi::ByteString;
 use kube::api::Meta;
 use kube::api::{Api, PostParams};
 use std::collections::BTreeMap;
+use uuid::Uuid;
 
 pub type Certificate = Secret;
 
-pub async fn create(store: &Store, cert_issuer: &CertIssuer) -> Result<Certificate, Error> {
+async fn cache_and_create_for_namespaces(
+    store: &Store,
+    cert_issuer: &CertIssuer,
+) -> Result<Vec<Certificate>, Error> {
+    match create_cache(&store, &cert_issuer).await {
+        Ok(cached_cert) => {
+            let create_futures = cert_issuer
+                .spec
+                .namespaces
+                .iter()
+                .map(|ns| create_from_cached_cert(store, &cached_cert, &ns));
+
+            let created_certificates: Vec<Certificate> = future::join_all(create_futures)
+                .await
+                .into_iter()
+                .filter_map(Result::ok)
+                .collect();
+
+            Ok(created_certificates)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn create_cache(store: &Store, cert_issuer: &CertIssuer) -> Result<Certificate, Error> {
     let cert_issuer = cert_issuer.clone();
-    let name = cert_issuer
+    let cert_issuer_name = cert_issuer
         .meta()
         .name
         .as_ref()
         .ok_or(Error::MissingObjectKey(".meta.name"))?
         .to_string();
+
+    let cert_name = cert_issuer
+        .clone()
+        .spec
+        .secret_name
+        .unwrap_or_else(|| cert_issuer_name.clone());
+
+    let cache_name = Uuid::new_v4().to_string();
 
     let contents: BTreeMap<String, ByteString> = vec![(
         "content".to_string(),
@@ -28,21 +62,21 @@ pub async fn create(store: &Store, cert_issuer: &CertIssuer) -> Result<Certifica
 
     let labels: BTreeMap<String, String> = vec![
         (
-            "manager".to_string(),
-            "certmaster.kuberails.com".to_string(),
+            "app.kubernetes.io/managed-by",
+            "certmaster.kuberails.com/v1",
         ),
-        (
-            "certmaster.kuberails.com/certIssuer".to_string(),
-            name.clone(),
-        ),
+        ("certmaster.kuberails.com/certIssuer", &cert_issuer_name),
+        ("certmaster.kuberails.com/certName", &cert_name),
+        ("certmaster.kuberails.com/cached", "true"),
     ]
     .into_iter()
+    .map(|(key, value)| (key.to_string(), value.to_string()))
     .collect();
 
     let cert = Certificate {
         metadata: ObjectMeta {
-            name: Some(name),
-            namespace: Some("avencera".to_string()),
+            name: Some(cache_name),
+            namespace: Some(store.get_namespace().to_string()),
             owner_references: Some(vec![OwnerReference {
                 controller: Some(true),
                 ..cert_issuer::owner_reference(cert_issuer)?
@@ -50,11 +84,56 @@ pub async fn create(store: &Store, cert_issuer: &CertIssuer) -> Result<Certifica
             labels: Some(labels),
             ..ObjectMeta::default()
         },
+        // type_: Some("kubernetes.io/tls".to_string()),
         data: Some(contents),
         ..Default::default()
     };
 
-    let cert_api = Api::<Certificate>::namespaced(store.get_client().clone(), "avencera");
+    let cert_api =
+        Api::<Certificate>::namespaced(store.get_client().clone(), store.get_namespace());
+    let pp = PostParams::default();
+
+    Ok(cert_api.create(&pp, &cert).await?)
+}
+
+async fn create_from_cached_cert(
+    store: &Store,
+    secret: &Secret,
+    ns: &str,
+) -> Result<Certificate, Error> {
+    let secret = secret.clone();
+
+    let mut labels = secret
+        .clone()
+        .metadata
+        .labels
+        .unwrap_or_else(|| BTreeMap::new());
+
+    let name = labels
+        .get("certmaster.kuberails.com/certName")
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    labels.remove("certmaster.kuberails.com/cached");
+    labels.insert(
+        "certmaster.kuberails.com/cacheName".to_string(),
+        secret.clone().name(),
+    );
+
+    let cert = Certificate {
+        metadata: ObjectMeta {
+            name: Some(name),
+            namespace: Some(ns.to_string()),
+            owner_references: secret.metadata.owner_references,
+            labels: Some(labels),
+            ..ObjectMeta::default()
+        },
+        type_: Some("kubernetes.io/tls".to_string()),
+        data: secret.data,
+        ..Default::default()
+    };
+
+    let cert_api = Api::<Certificate>::namespaced(store.get_client().clone(), ns);
     let pp = PostParams::default();
 
     Ok(cert_api.create(&pp, &cert).await?)

--- a/controller/src/certificate.rs
+++ b/controller/src/certificate.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 pub type Certificate = Secret;
 
-async fn cache_and_create_for_namespaces(
+pub async fn cache_and_create_for_namespaces(
     store: &Store,
     cert_issuer: &CertIssuer,
 ) -> Result<Vec<Certificate>, Error> {
@@ -56,12 +56,11 @@ async fn create_cache(store: &Store, cert_issuer: &CertIssuer) -> Result<Certifi
 
     let cache_name = Uuid::new_v4().to_string();
 
-    let contents: BTreeMap<String, ByteString> = vec![(
-        "content".to_string(),
-        ByteString("hello".as_bytes().to_vec()),
-    )]
-    .into_iter()
-    .collect();
+    let contents: BTreeMap<String, ByteString> =
+        vec![("tls.crt", "tls.crt.data"), ("tls.key", "tls.key.data")]
+            .iter()
+            .map(|(key, value)| (key.to_string(), ByteString(value.as_bytes().to_vec())))
+            .collect();
 
     let labels: BTreeMap<String, String> = vec![
         (MANAGED_BY_KEY, MANAGED_BY_VALUE),

--- a/controller/src/certificate.rs
+++ b/controller/src/certificate.rs
@@ -25,7 +25,7 @@ pub async fn cache_and_create_for_namespaces(
                 .spec
                 .namespaces
                 .iter()
-                .map(|ns| create_from_cached_cert(store, &cached_cert, &ns))
+                .map(|ns| create_from_cache(store, &cached_cert, &ns))
                 .collect::<FuturesUnordered<_>>()
                 .collect::<Vec<_>>()
                 .await
@@ -94,11 +94,7 @@ async fn create_cache(store: &Store, cert_issuer: &CertIssuer) -> Result<Certifi
     Ok(cert_api.create(&pp, &cert).await?)
 }
 
-async fn create_from_cached_cert(
-    store: &Store,
-    secret: &Secret,
-    ns: &str,
-) -> Result<Certificate, Error> {
+async fn create_from_cache(store: &Store, secret: &Secret, ns: &str) -> Result<Certificate, Error> {
     let secret = secret.clone();
 
     let mut labels = secret

--- a/controller/src/consts/labels.rs
+++ b/controller/src/consts/labels.rs
@@ -1,0 +1,10 @@
+pub const CACHED: &str = "certmaster.kuberails.com/cached";
+pub const CACHE_NAME: &str = "certmaster.kuberails.com/cacheName";
+
+pub const CERT_ISSUER: &str = "certmaster.kuberails.com/certIssuer";
+pub const CERT_NAME: &str = "certmaster.kuberails.com/certName";
+
+pub const MANAGED_BY_KEY: &str = "app.kubernetes.io/managed-by";
+pub const MANAGED_BY_VALUE: &str = "v1.certmaster.kuberails.com";
+
+pub const TLS: &str = "kubernetes.io/tls";

--- a/controller/src/consts/mod.rs
+++ b/controller/src/consts/mod.rs
@@ -1,0 +1,1 @@
+pub mod labels;

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cert_issuer;
 pub mod certificate;
+pub mod consts;
 pub mod error;
 pub mod store;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,5 +1,6 @@
 use certmaster::cert_issuer::CertIssuer;
 use certmaster::certificate::{self, Certificate};
+use certmaster::error::Error;
 use certmaster::store::Store;
 use futures::prelude::*;
 use kube::{
@@ -45,7 +46,7 @@ async fn cert_watcher(api: Api<Certificate>, store: Store) -> Result<(), JoinErr
     task::spawn(async move {
         let lp = ListParams::default()
             .timeout(60)
-            .labels("manager=certmaster.kuberails.com,certmaster.kuberails.com/certIssuer");
+            .labels("app.kubernetes.io/managed-by=certmaster.kuberails.com/v1,certmaster.kuberails.com/certIssuer");
 
         let watcher = watcher(api, lp);
 
@@ -61,10 +62,7 @@ async fn handle_cert_issuer_events(
     store: Store,
 ) -> Result<(), watcher::Error> {
     match event {
-        watcher::Event::Applied(cert_issuer) => {
-            let _ = certificate::create(&store, &cert_issuer).await;
-            ()
-        }
+        watcher::Event::Applied(cert_issuer) => {}
         _ => (),
     }
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -70,6 +70,7 @@ async fn handle_cert_issuer_events(
             let res = certificate::cache_and_create_for_namespaces(&store, &cert_issuer).await;
 
             if let Ok(certificates) = res {
+                //TODO:
                 // save certificates to store
             }
             ()

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,6 +1,6 @@
 use certmaster::cert_issuer::CertIssuer;
-use certmaster::certificate::{self, Certificate};
-use certmaster::error::Error;
+use certmaster::certificate::Certificate;
+use certmaster::consts::labels::{CACHED, CERT_ISSUER, MANAGED_BY_KEY, MANAGED_BY_VALUE};
 use certmaster::store::Store;
 use futures::prelude::*;
 use kube::{
@@ -44,9 +44,13 @@ async fn cert_issuer_watcher(api: Api<CertIssuer>, store: Store) -> Result<(), J
 
 async fn cert_watcher(api: Api<Certificate>, store: Store) -> Result<(), JoinError> {
     task::spawn(async move {
-        let lp = ListParams::default()
-            .timeout(60)
-            .labels("app.kubernetes.io/managed-by=certmaster.kuberails.com/v1,certmaster.kuberails.com/certIssuer");
+        let lp = ListParams::default().timeout(60).labels(&format!(
+            "{managed_by_key}={managed_by_value},{cert_issuer},{cached}!=true",
+            managed_by_key = MANAGED_BY_KEY,
+            managed_by_value = MANAGED_BY_VALUE,
+            cert_issuer = CERT_ISSUER,
+            cached = CACHED
+        ));
 
         let watcher = watcher(api, lp);
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,5 +1,5 @@
 use certmaster::cert_issuer::CertIssuer;
-use certmaster::certificate::Certificate;
+use certmaster::certificate::{self, Certificate};
 use certmaster::consts::labels::{CACHED, CERT_ISSUER, MANAGED_BY_KEY, MANAGED_BY_VALUE};
 use certmaster::store::Store;
 use futures::prelude::*;
@@ -66,7 +66,14 @@ async fn handle_cert_issuer_events(
     store: Store,
 ) -> Result<(), watcher::Error> {
     match event {
-        watcher::Event::Applied(cert_issuer) => {}
+        watcher::Event::Applied(cert_issuer) => {
+            let res = certificate::cache_and_create_for_namespaces(&store, &cert_issuer).await;
+
+            if let Ok(certificates) = res {
+                // save certificates to store
+            }
+            ()
+        }
         _ => (),
     }
 
@@ -77,7 +84,7 @@ async fn handle_cert_events(
     event: watcher::Event<Certificate>,
     store: Store,
 ) -> Result<(), watcher::Error> {
-    println!("CERT: {:#?}", event);
+    println!("CERT: {:?}", event);
 
     Ok(())
 }

--- a/controller/src/store.rs
+++ b/controller/src/store.rs
@@ -14,6 +14,7 @@ pub struct InnerStore {
 }
 
 struct ReadOnly {
+    namespace: String,
     client: Client,
 }
 
@@ -29,8 +30,10 @@ impl Store {
             certs: vec![],
         };
 
+        let namespace = std::env::var("NAMESPACE").unwrap_or("kuberails".to_string());
+
         let inner = InnerStore {
-            readonly: ReadOnly { client },
+            readonly: ReadOnly { client, namespace },
             state: RwLock::new(state),
         };
 
@@ -42,7 +45,15 @@ impl Store {
     }
 
     pub fn get_client(&self) -> &Client {
-        &self.get_ref().readonly.client
+        &self.get_read_only().client
+    }
+
+    pub fn get_namespace(&self) -> &String {
+        &self.get_read_only().namespace
+    }
+
+    fn get_read_only(&self) -> &ReadOnly {
+        &self.get_ref().readonly
     }
 
     async fn add_cert_issuer(&self, cert_issuer: &CertIssuer) -> () {


### PR DESCRIPTION
## Future refactoring opportunities 

* Create certificate struct and make functions method of that?
   * would have to pick a different name for type alias for `Secret`, or just use `Secret` instead of alias `Certificate`

* Add domains and expirations as annotations on the cache and certificates 
   * could you make immutable annotations?
   * maybe just better to certissuer

* Make certificates have the cache as an owner reference?
   * then deleting the cached certificate would automatically delete all certs in all namespaces which is valuable for dealing with expired certs